### PR TITLE
Feature/current item publisher

### DIFF
--- a/AVFoundation-Combine/AVPlayer+Publishers.swift
+++ b/AVFoundation-Combine/AVPlayer+Publishers.swift
@@ -33,6 +33,13 @@ public extension AVPlayer {
         return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath)
     }
     
+    /// Publisher for the `currentItem` property
+    /// - Returns: Publisher for the `currentItem` property
+    func currentItemPublisher() -> AnyPublisher<AVPlayerItem?, Never> {
+        let keyPath: KeyPath<AVPlayer, AVPlayerItem?> = \.currentItem
+        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath).eraseToAnyPublisher()
+    }
+    
     // MARK: AVPlayerItem Publishers
     
     /// Publisher for the `status` property in `AVPlayer.currentItem`

--- a/AVFoundation-Combine/ViewController.swift
+++ b/AVFoundation-Combine/ViewController.swift
@@ -12,16 +12,26 @@ import AVKit
 import Combine
 
 class ViewController: AVPlayerViewController {
+    
+    /// A sample video URL
     private let videoURL = URL(string: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")!
+    
+    /// A set to store all our Publisher susbcriptions
     private var subscriptions = Set<AnyCancellable>()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let player = AVPlayer(url: videoURL)
+        let player = AVPlayer()
+        
+        player.currentItemPublisher()
+            .sink { item in
+                print(">> current item: \(String(describing: item))")
+            }
+            .store(in: &subscriptions)
         
         player.playheadProgressPublisher()
             .sink { (time) in
-                print("received playhead progress: \(time)")
+                print(">> received playhead progress: \(time)")
             }
             .store(in: &subscriptions)
         
@@ -45,9 +55,9 @@ class ViewController: AVPlayerViewController {
             .sink { (rate) in
                 print("rate changed:")
                 switch rate {
-                case 0:
+                case 0.0:
                     print(">> paused")
-                case 1:
+                case 1.0:
                     print(">> playing")
                 default:
                     print(">> \(rate)")
@@ -61,6 +71,8 @@ class ViewController: AVPlayerViewController {
             }
             .store(in: &subscriptions)
         
+        // Load our sample video
+        player.replaceCurrentItem(with: AVPlayerItem(url: videoURL))
         self.player = player
     }
     


### PR DESCRIPTION
I have added `currentItemPublisher()` which understandably only emits events in our sample application if the subscription happens before `currentItem` is actually set. 

I was curious about how to achieve what on `RxSwift` we would call a `ReplaySubject` so that i could subscribe after `currentItem` has been set and still get notified of the values that changed before the subscription. 

According to this cheatsheet https://github.com/CombineCommunity/rxswift-to-combine-cheatsheet this is not available (?), i will need to read up more on that.

For the time being the sample project loads the video after all the subscriptions have happened.