### PR TITLE
Add unit tests for publishers

### DIFF
--- a/AVFoundation-Combine.xcodeproj/project.pbxproj
+++ b/AVFoundation-Combine.xcodeproj/project.pbxproj
@@ -17,7 +17,18 @@
 		BB4A48EA24C090900004DBA5 /* PlayheadProgressPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A48E924C090900004DBA5 /* PlayheadProgressPublisher.swift */; };
 		BB4A48EE24C090D00004DBA5 /* AVPlayer+Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A48ED24C090D00004DBA5 /* AVPlayer+Publishers.swift */; };
 		BBC7B70C24C1B62F00093E88 /* KVObservingPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7B70B24C1B62F00093E88 /* KVObservingPublisher.swift */; };
+		BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BBFA8AC624C9D7B300AC9D67 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BB4A48CA24C090540004DBA5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BB4A48D124C090540004DBA5;
+			remoteInfo = "AVFoundation-Combine";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		4FF363DD24C17FF700153AA5 /* AVPlayerItem+Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayerItem+Publishers.swift"; sourceTree = "<group>"; };
@@ -32,10 +43,20 @@
 		BB4A48E924C090900004DBA5 /* PlayheadProgressPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadProgressPublisher.swift; sourceTree = "<group>"; };
 		BB4A48ED24C090D00004DBA5 /* AVPlayer+Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Publishers.swift"; sourceTree = "<group>"; };
 		BBC7B70B24C1B62F00093E88 /* KVObservingPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVObservingPublisher.swift; sourceTree = "<group>"; };
+		BBFA8AC124C9D7B300AC9D67 /* AVFoundation-CombineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AVFoundation-CombineTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BBFA8AC524C9D7B300AC9D67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVObservingPublisherTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		BB4A48CF24C090540004DBA5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BBFA8ABE24C9D7B300AC9D67 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -49,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				BB4A48D424C090540004DBA5 /* AVFoundation-Combine */,
+				BBFA8AC224C9D7B300AC9D67 /* AVFoundation-CombineTests */,
 				BB4A48D324C090540004DBA5 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -57,6 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				BB4A48D224C090540004DBA5 /* AVFoundation-Combine.app */,
+				BBFA8AC124C9D7B300AC9D67 /* AVFoundation-CombineTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -95,6 +118,15 @@
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		BBFA8AC224C9D7B300AC9D67 /* AVFoundation-CombineTests */ = {
+			isa = PBXGroup;
+			children = (
+				BBFA8AC524C9D7B300AC9D67 /* Info.plist */,
+				BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */,
+			);
+			path = "AVFoundation-CombineTests";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -115,18 +147,40 @@
 			productReference = BB4A48D224C090540004DBA5 /* AVFoundation-Combine.app */;
 			productType = "com.apple.product-type.application";
 		};
+		BBFA8AC024C9D7B300AC9D67 /* AVFoundation-CombineTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BBFA8ACA24C9D7B300AC9D67 /* Build configuration list for PBXNativeTarget "AVFoundation-CombineTests" */;
+			buildPhases = (
+				BBFA8ABD24C9D7B300AC9D67 /* Sources */,
+				BBFA8ABE24C9D7B300AC9D67 /* Frameworks */,
+				BBFA8ABF24C9D7B300AC9D67 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BBFA8AC724C9D7B300AC9D67 /* PBXTargetDependency */,
+			);
+			name = "AVFoundation-CombineTests";
+			productName = "AVFoundation-CombineTests";
+			productReference = BBFA8AC124C9D7B300AC9D67 /* AVFoundation-CombineTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		BB4A48CA24C090540004DBA5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1150;
+				LastSwiftUpdateCheck = 1160;
 				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = "József Vesza";
 				TargetAttributes = {
 					BB4A48D124C090540004DBA5 = {
 						CreatedOnToolsVersion = 11.5;
+					};
+					BBFA8AC024C9D7B300AC9D67 = {
+						CreatedOnToolsVersion = 11.6;
+						TestTargetID = BB4A48D124C090540004DBA5;
 					};
 				};
 			};
@@ -144,6 +198,7 @@
 			projectRoot = "";
 			targets = (
 				BB4A48D124C090540004DBA5 /* AVFoundation-Combine */,
+				BBFA8AC024C9D7B300AC9D67 /* AVFoundation-CombineTests */,
 			);
 		};
 /* End PBXProject section */
@@ -156,6 +211,13 @@
 				BB4A48E224C090560004DBA5 /* LaunchScreen.storyboard in Resources */,
 				BB4A48DF24C090560004DBA5 /* Assets.xcassets in Resources */,
 				BB4A48DD24C090540004DBA5 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BBFA8ABF24C9D7B300AC9D67 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,7 +238,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BBFA8ABD24C9D7B300AC9D67 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BBFA8AC724C9D7B300AC9D67 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BB4A48D124C090540004DBA5 /* AVFoundation-Combine */;
+			targetProxy = BBFA8AC624C9D7B300AC9D67 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		BB4A48DB24C090540004DBA5 /* Main.storyboard */ = {
@@ -348,6 +426,48 @@
 			};
 			name = Release;
 		};
+		BBFA8AC824C9D7B300AC9D67 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2Q6B2J7LRM;
+				INFOPLIST_FILE = "AVFoundation-CombineTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "hu.jozsefvesza.AVFoundation-CombineTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AVFoundation-Combine.app/AVFoundation-Combine";
+			};
+			name = Debug;
+		};
+		BBFA8AC924C9D7B300AC9D67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2Q6B2J7LRM;
+				INFOPLIST_FILE = "AVFoundation-CombineTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "hu.jozsefvesza.AVFoundation-CombineTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AVFoundation-Combine.app/AVFoundation-Combine";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -365,6 +485,15 @@
 			buildConfigurations = (
 				BB4A48E724C090560004DBA5 /* Debug */,
 				BB4A48E824C090560004DBA5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BBFA8ACA24C9D7B300AC9D67 /* Build configuration list for PBXNativeTarget "AVFoundation-CombineTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BBFA8AC824C9D7B300AC9D67 /* Debug */,
+				BBFA8AC924C9D7B300AC9D67 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AVFoundation-Combine.xcodeproj/project.pbxproj
+++ b/AVFoundation-Combine.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BB4A48EE24C090D00004DBA5 /* AVPlayer+Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A48ED24C090D00004DBA5 /* AVPlayer+Publishers.swift */; };
 		BBC7B70C24C1B62F00093E88 /* KVObservingPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7B70B24C1B62F00093E88 /* KVObservingPublisher.swift */; };
 		BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */; };
+		BBFA8ACE24CACA6E00AC9D67 /* PlayheadProgressPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACD24CACA6E00AC9D67 /* PlayheadProgressPublisherTests.swift */; };
 		BBFA8AD024CAD74600AC9D67 /* TestSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */; };
 /* End PBXBuildFile section */
 
@@ -47,6 +48,7 @@
 		BBFA8AC124C9D7B300AC9D67 /* AVFoundation-CombineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AVFoundation-CombineTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBFA8AC524C9D7B300AC9D67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVObservingPublisherTests.swift; sourceTree = "<group>"; };
+		BBFA8ACD24CACA6E00AC9D67 /* PlayheadProgressPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadProgressPublisherTests.swift; sourceTree = "<group>"; };
 		BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSubscriber.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -125,6 +127,7 @@
 			children = (
 				BBFA8AC524C9D7B300AC9D67 /* Info.plist */,
 				BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */,
+				BBFA8ACD24CACA6E00AC9D67 /* PlayheadProgressPublisherTests.swift */,
 				BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */,
 			);
 			path = "AVFoundation-CombineTests";
@@ -247,6 +250,7 @@
 			files = (
 				BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */,
 				BBFA8AD024CAD74600AC9D67 /* TestSubscriber.swift in Sources */,
+				BBFA8ACE24CACA6E00AC9D67 /* PlayheadProgressPublisherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AVFoundation-Combine.xcodeproj/project.pbxproj
+++ b/AVFoundation-Combine.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 22E8VLPFF8;
 				INFOPLIST_FILE = "AVFoundation-Combine/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -423,6 +424,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 22E8VLPFF8;
 				INFOPLIST_FILE = "AVFoundation-Combine/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AVFoundation-Combine.xcodeproj/project.pbxproj
+++ b/AVFoundation-Combine.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BB4A48EE24C090D00004DBA5 /* AVPlayer+Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A48ED24C090D00004DBA5 /* AVPlayer+Publishers.swift */; };
 		BBC7B70C24C1B62F00093E88 /* KVObservingPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7B70B24C1B62F00093E88 /* KVObservingPublisher.swift */; };
 		BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */; };
+		BBFA8AD024CAD74600AC9D67 /* TestSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		BBFA8AC124C9D7B300AC9D67 /* AVFoundation-CombineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AVFoundation-CombineTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBFA8AC524C9D7B300AC9D67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVObservingPublisherTests.swift; sourceTree = "<group>"; };
+		BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSubscriber.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 			children = (
 				BBFA8AC524C9D7B300AC9D67 /* Info.plist */,
 				BBFA8ACB24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift */,
+				BBFA8ACF24CAD74600AC9D67 /* TestSubscriber.swift */,
 			);
 			path = "AVFoundation-CombineTests";
 			sourceTree = "<group>";
@@ -243,6 +246,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BBFA8ACC24C9D7EE00AC9D67 /* KVObservingPublisherTests.swift in Sources */,
+				BBFA8AD024CAD74600AC9D67 /* TestSubscriber.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
+++ b/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
@@ -56,7 +56,9 @@ public extension Publishers {
                 let newDemand = subscriber.receive(newValue)
                 self.requested += newDemand
                 
-                self.completeIfNeeded()
+                if self.requested == .none {
+                    subscriber.receive(completion: .finished)
+                }
             }
         }
         

--- a/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
+++ b/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
@@ -47,7 +47,6 @@ public extension Publishers {
         
         func request(_ demand: Subscribers.Demand) {
             requested += demand
-            completeIfNeeded()
             guard observationToken == nil, requested > .none else { return }
             
             observationToken = observedObject.observe(keyPath, options: [.old, .new]) { [weak self] (object, change) in

--- a/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
+++ b/AVFoundation-Combine/Publishers/KVObservingPublisher.swift
@@ -47,19 +47,17 @@ public extension Publishers {
         
         func request(_ demand: Subscribers.Demand) {
             requested += demand
-            
             completeIfNeeded()
+            guard timeObserverToken == nil, requested > .none else { return }
             
-            if observationToken == nil, requested > .none {
-                observationToken = observedObject.observe(keyPath, options: [.old, .new]) { [weak self] (object, change) in
-                    guard let self = self, let subscriber = self.subscriber else { return }
-                    let newValue = change.newValue ?? object[keyPath: self.keyPath]
-                    self.requested -= .max(1)
-                    let newDemand = subscriber.receive(newValue)
-                    self.requested += newDemand
-                    
-                    self.completeIfNeeded()
-                }
+            observationToken = observedObject.observe(keyPath, options: [.old, .new]) { [weak self] (object, change) in
+                guard let self = self, let subscriber = self.subscriber else { return }
+                let newValue = change.newValue ?? object[keyPath: self.keyPath]
+                self.requested -= .max(1)
+                let newDemand = subscriber.receive(newValue)
+                self.requested += newDemand
+                
+                self.completeIfNeeded()
             }
         }
         

--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -55,7 +55,10 @@ public extension Publishers {
                 self.requested -= .max(1)
                 let newDemand = subscriber.receive(time.seconds)
                 self.requested += newDemand
-                self.completeIfNeeded()
+                
+                if self.requested == .none {
+                    subscriber.receive(completion: .finished)
+                }
             }
         }
         
@@ -65,12 +68,6 @@ public extension Publishers {
             }
             timeObserverToken = nil
             subscriber = nil
-        }
-        
-        private func completeIfNeeded() {
-            if requested == .none {
-                subscriber?.receive(completion: .finished)
-            }
         }
     }
 }

--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -47,7 +47,6 @@ public extension Publishers {
         
         func request(_ demand: Subscribers.Demand) {
             requested += demand
-            completeIfNeeded()
             guard timeObserverToken == nil, requested > .none else { return }
             
             let interval = CMTime(seconds: self.interval, preferredTimescale: CMTimeScale(NSEC_PER_SEC))

--- a/AVFoundation-Combine/ViewController.swift
+++ b/AVFoundation-Combine/ViewController.swift
@@ -17,55 +17,55 @@ class ViewController: AVPlayerViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let player = AVPlayer(url: videoURL)
-        
-        player.playheadProgressPublisher()
-            .sink { (time) in
-                print("received playhead progress: \(time)")
-            }
-            .store(in: &subscriptions)
-        
-        player.statusPublisher()
-            .sink { status in
-                print("received status:")
-                switch status {
-                case .unknown:
-                    print(">> unknown")
-                case .readyToPlay:
-                    print(">> ready to play")
-                case .failed:
-                    print(">> failed")
-                @unknown default:
-                    print(">> other")
-                }
-            }
-            .store(in: &subscriptions)
-        
-        player.ratePublisher()
-            .sink { (rate) in
-                print("rate changed:")
-                switch rate {
-                case 0:
-                    print(">> paused")
-                case 1:
-                    print(">> playing")
-                default:
-                    print(">> \(rate)")
-                }
-            }
-            .store(in: &subscriptions)
-        
-        player.isPlaybackLikelyToKeepUpPublisher()
-            .sink {isPlaybackLikelyToKeepUp in
-                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
-            }
-            .store(in: &subscriptions)
-        
-        self.player = player
+//        let player = AVPlayer(url: videoURL)
+//
+//        player.playheadProgressPublisher()
+//            .sink { (time) in
+//                print("received playhead progress: \(time)")
+//            }
+//            .store(in: &subscriptions)
+//
+//        player.statusPublisher()
+//            .sink { status in
+//                print("received status:")
+//                switch status {
+//                case .unknown:
+//                    print(">> unknown")
+//                case .readyToPlay:
+//                    print(">> ready to play")
+//                case .failed:
+//                    print(">> failed")
+//                @unknown default:
+//                    print(">> other")
+//                }
+//            }
+//            .store(in: &subscriptions)
+//
+//        player.ratePublisher()
+//            .sink { (rate) in
+//                print("rate changed:")
+//                switch rate {
+//                case 0:
+//                    print(">> paused")
+//                case 1:
+//                    print(">> playing")
+//                default:
+//                    print(">> \(rate)")
+//                }
+//            }
+//            .store(in: &subscriptions)
+//
+//        player.isPlaybackLikelyToKeepUpPublisher()
+//            .sink {isPlaybackLikelyToKeepUp in
+//                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
+//            }
+//            .store(in: &subscriptions)
+//
+//        self.player = player
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        player?.play()
+//        player?.play()
     }
 }

--- a/AVFoundation-Combine/ViewController.swift
+++ b/AVFoundation-Combine/ViewController.swift
@@ -17,55 +17,55 @@ class ViewController: AVPlayerViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        let player = AVPlayer(url: videoURL)
-//
-//        player.playheadProgressPublisher()
-//            .sink { (time) in
-//                print("received playhead progress: \(time)")
-//            }
-//            .store(in: &subscriptions)
-//
-//        player.statusPublisher()
-//            .sink { status in
-//                print("received status:")
-//                switch status {
-//                case .unknown:
-//                    print(">> unknown")
-//                case .readyToPlay:
-//                    print(">> ready to play")
-//                case .failed:
-//                    print(">> failed")
-//                @unknown default:
-//                    print(">> other")
-//                }
-//            }
-//            .store(in: &subscriptions)
-//
-//        player.ratePublisher()
-//            .sink { (rate) in
-//                print("rate changed:")
-//                switch rate {
-//                case 0:
-//                    print(">> paused")
-//                case 1:
-//                    print(">> playing")
-//                default:
-//                    print(">> \(rate)")
-//                }
-//            }
-//            .store(in: &subscriptions)
-//
-//        player.isPlaybackLikelyToKeepUpPublisher()
-//            .sink {isPlaybackLikelyToKeepUp in
-//                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
-//            }
-//            .store(in: &subscriptions)
-//
-//        self.player = player
+        let player = AVPlayer(url: videoURL)
+
+        player.playheadProgressPublisher()
+            .sink { (time) in
+                print("received playhead progress: \(time)")
+            }
+            .store(in: &subscriptions)
+
+        player.statusPublisher()
+            .sink { status in
+                print("received status:")
+                switch status {
+                case .unknown:
+                    print(">> unknown")
+                case .readyToPlay:
+                    print(">> ready to play")
+                case .failed:
+                    print(">> failed")
+                @unknown default:
+                    print(">> other")
+                }
+            }
+            .store(in: &subscriptions)
+
+        player.ratePublisher()
+            .sink { (rate) in
+                print("rate changed:")
+                switch rate {
+                case 0:
+                    print(">> paused")
+                case 1:
+                    print(">> playing")
+                default:
+                    print(">> \(rate)")
+                }
+            }
+            .store(in: &subscriptions)
+
+        player.isPlaybackLikelyToKeepUpPublisher()
+            .sink {isPlaybackLikelyToKeepUp in
+                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
+            }
+            .store(in: &subscriptions)
+
+        self.player = player
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-//        player?.play()
+        player?.play()
     }
 }

--- a/AVFoundation-CombineTests/Info.plist
+++ b/AVFoundation-CombineTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/AVFoundation-CombineTests/KVObservingPublisherTests.swift
+++ b/AVFoundation-CombineTests/KVObservingPublisherTests.swift
@@ -58,7 +58,7 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenNoValuesAreRequested_ItCompletesImmediately() {
+    func testWhenNoValuesAreRequested_ItEmitsNoValues() {
         // given
         let expectedValues: [Int] = []
         var receivedValues: [Int] = []
@@ -70,6 +70,26 @@ class KVObservingPublisherTests: XCTestCase {
         sut.subscribe(subscriber)
         
         // when
+        (0..<5).forEach { _ in counter.increment() }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
+    func testWhenValuesAreRequested_ItStartsEmittingValues() {
+        // given
+        let expectedValues: [Int] = [1, 2, 3, 4, 5]
+        var receivedValues: [Int] = []
+        
+        let subscriber = TestSubscriber<Int>(demand: 0) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        // when
+        subscriber.startRequestingValues(5)
+        
         (0..<5).forEach { _ in counter.increment() }
         
         // then

--- a/AVFoundation-CombineTests/KVObservingPublisherTests.swift
+++ b/AVFoundation-CombineTests/KVObservingPublisherTests.swift
@@ -58,6 +58,24 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
+    func testWhenNoValuesAreRequested_ItCompletesImmediately() {
+        // given
+        let expectedValues: [Int] = []
+        var receivedValues: [Int] = []
+        
+        let subscriber = CountSubscriber(demand: 0) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        // when
+        (0..<5).forEach { _ in counter.increment() }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
     func testWhenOnlyOneValueIsRequested_ItCompletesAfterEmittingOneValue() {
         // given
         let expectedValues = [1]

--- a/AVFoundation-CombineTests/KVObservingPublisherTests.swift
+++ b/AVFoundation-CombineTests/KVObservingPublisherTests.swift
@@ -25,7 +25,7 @@ class KVObservingPublisherTests: XCTestCase {
         subscriptions = []
     }
     
-    func testWhenCounterIsIncremented_ItEmitsTheNewValue() {
+    func testWhenDemandIsUnlimited_AndCounterIsIncremented_ItEmitsTheNewValue() {
         // given
         let expectation = XCTestExpectation(description: "Value should be received")
         sut.sink { _ in
@@ -40,7 +40,7 @@ class KVObservingPublisherTests: XCTestCase {
         wait(for: [expectation], timeout: 0)
     }
     
-    func testWhenCounterIsIncrementedTwice_ItEmitsTwoValues() {
+    func testWhenDemandIsUnlimited_AndCounterIsIncrementedTwice_ItEmitsTwoValues() {
         // given
         let expectedValues = [1, 2]
         var receivedValues: [Int] = []
@@ -58,7 +58,7 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenNoValuesAreRequested_ItEmitsNoValues() {
+    func testWhenDemandIsZero_ItEmitsNoValues() {
         // given
         let expectedValues: [Int] = []
         var receivedValues: [Int] = []
@@ -76,7 +76,7 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenValuesAreRequested_ItStartsEmittingValues() {
+    func testWhenInitialDemandIsZero_AndThenFiveValuesAreRequested_ItEmitsFiveValues() {
         // given
         let expectedValues: [Int] = [1, 2, 3, 4, 5]
         var receivedValues: [Int] = []
@@ -96,7 +96,7 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenOnlyOneValueIsRequested_ItCompletesAfterEmittingOneValue() {
+    func testWhenDemandIsOne_ItCompletesAfterEmittingOneValue() {
         // given
         let expectedValues = [1]
         var receivedValues: [Int] = []
@@ -114,7 +114,7 @@ class KVObservingPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenTwoValuesAreRequested_ItCompletesAfterEmittingTwoValues() {
+    func testWhenDemandIsTwo_ItCompletesAfterEmittingTwoValues() {
         // given
         let expectedValues = [1, 2]
         var receivedValues: [Int] = []

--- a/AVFoundation-CombineTests/KVObservingPublisherTests.swift
+++ b/AVFoundation-CombineTests/KVObservingPublisherTests.swift
@@ -63,7 +63,7 @@ class KVObservingPublisherTests: XCTestCase {
         let expectedValues: [Int] = []
         var receivedValues: [Int] = []
         
-        let subscriber = CountSubscriber(demand: 0) { values in
+        let subscriber = TestSubscriber<Int>(demand: 0) { values in
             receivedValues = values
         }
         
@@ -81,7 +81,7 @@ class KVObservingPublisherTests: XCTestCase {
         let expectedValues = [1]
         var receivedValues: [Int] = []
         
-        let subscriber = CountSubscriber(demand: 1) { values in
+        let subscriber = TestSubscriber<Int>(demand: 1) { values in
             receivedValues = values
         }
         
@@ -99,7 +99,7 @@ class KVObservingPublisherTests: XCTestCase {
         let expectedValues = [1, 2]
         var receivedValues: [Int] = []
         
-        let subscriber = CountSubscriber(demand: 2) { values in
+        let subscriber = TestSubscriber<Int>(demand: 2) { values in
             receivedValues = values
         }
         
@@ -118,36 +118,5 @@ class Counter: NSObject {
     
     func increment() {
         count += 1
-    }
-}
-
-class CountSubscriber: Subscriber {
-    typealias Input = Int
-    typealias Failure = Never
-    
-    let demand: Int
-    let onComplete: ([Int]) -> Void
-    
-    private var receivedValues: [Int] = []
-    private var subscription: Subscription? = nil
-    
-    init(demand: Int, onComplete: @escaping ([Int]) -> Void) {
-        self.demand = demand
-        self.onComplete = onComplete
-    }
-    
-    func receive(subscription: Subscription) {
-        self.subscription = subscription
-        subscription.request(.max(demand))
-    }
-    
-    func receive(_ input: Int) -> Subscribers.Demand {
-        receivedValues.append(input)
-        return .none
-    }
-    
-    func receive(completion: Subscribers.Completion<Never>) {
-        onComplete(receivedValues)
-        subscription = nil
     }
 }

--- a/AVFoundation-CombineTests/KVObservingPublisherTests.swift
+++ b/AVFoundation-CombineTests/KVObservingPublisherTests.swift
@@ -1,0 +1,116 @@
+//
+//  KVObservingPublisherTests.swift
+//  AVFoundation-CombineTests
+//
+//  Created by József Vesza on 2020. 07. 23..
+//  Copyright © 2020. József Vesza. All rights reserved.
+//
+
+import XCTest
+import Combine
+
+@testable import AVFoundation_Combine
+
+class KVObservingPublisherTests: XCTestCase {
+    var sut: Publishers.KVObservingPublisher<Counter, Int>!
+    var counter: Counter!
+    var subscriptions = Set<AnyCancellable>()
+    
+    override func setUp() {
+        counter = Counter()
+        sut = Publishers.KVObservingPublisher(observedObject: counter, keyPath: \.count)
+    }
+    
+    override func tearDown() {
+        subscriptions = []
+    }
+    
+    func testWhenCounterIsIncremented_TheNewCountIsPublished() {
+        // given
+        let expectation = XCTestExpectation(description: "Value should be received")
+        sut.sink { _ in
+            expectation.fulfill()
+        }
+        .store(in: &subscriptions)
+        
+        // when
+        counter.increment()
+        
+        // then
+        wait(for: [expectation], timeout: 0)
+    }
+    
+    func testWhenTwoValuesAreReceived_ItEmitsTwoValues() {
+        // given
+        let expectation = XCTestExpectation(description: "Value should be received")
+        sut.sink { _ in
+            expectation.fulfill()
+        }
+        .store(in: &subscriptions)
+        
+        // when
+        counter.increment()
+        
+        // then
+        wait(for: [expectation], timeout: 0)
+    }
+    
+    func testWhenOnlyOneValueIsRequested_ItCompletesAfterEmittingOneValue() {
+        // given
+        let expectation = XCTestExpectation(description: "Value sould be 1")
+        let expectedValue = 1
+        
+        let subscriber = CountSubscriber(expectedDemand: expectedValue) { finalValue in
+            XCTAssertEqual(finalValue, expectedValue)
+            expectation.fulfill()
+        }
+        
+        sut.subscribe(subscriber)
+        
+        // when
+        (0..<5).forEach { _ in counter.increment() }
+        
+        // then
+        wait(for: [expectation], timeout: 1)
+    }
+}
+
+class Counter: NSObject {
+    @objc dynamic var count = 0
+    
+    func increment() {
+        count += 1
+    }
+}
+
+class CountSubscriber: Subscriber {
+    typealias Input = Int
+    typealias Failure = Never
+    
+    private(set) var receivedValue = 0
+    
+    let expectedDemand: Int
+    let onComplete: (Int) -> Void
+    
+    private var subscription: Subscription? = nil
+    
+    init(expectedDemand: Int, onComplete: @escaping (Int) -> Void) {
+        self.expectedDemand = expectedDemand
+        self.onComplete = onComplete
+    }
+    
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+        subscription.request(.max(expectedDemand))
+    }
+    
+    func receive(_ input: Int) -> Subscribers.Demand {
+        receivedValue = input
+        return .none
+    }
+    
+    func receive(completion: Subscribers.Completion<Never>) {
+        onComplete(receivedValue)
+        subscription = nil
+    }
+}

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -56,7 +56,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedTimes, expectedTimes)
     }
     
-    func testWhenNoValuesAreRequested_ItCompletesImmediately() {
+    func testWhenNoValuesAreRequested_ItEmitsNoValues() {
         // given
         let expectedValues: [TimeInterval] = []
         var receivedValues: [TimeInterval] = []
@@ -70,6 +70,28 @@ class PlayheadProgressPublisherTests: XCTestCase {
         let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
         
         // when
+        timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
+    func testWhenValuesAreRequested_ItStartsEmittingValues() {
+        // given
+        let expectedValues: [TimeInterval] = [1, 2, 3, 4, 5]
+        var receivedValues: [TimeInterval] = []
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        subscriber.startRequestingValues(5)
+        
         timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
         
         // then

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -1,0 +1,129 @@
+//
+//  PlayheadProgressPublisherTests.swift
+//  AVFoundation-CombineTests
+//
+//  Created by József Vesza on 2020. 07. 24..
+//  Copyright © 2020. József Vesza. All rights reserved.
+//
+
+import XCTest
+import Combine
+import AVFoundation
+
+@testable import AVFoundation_Combine
+
+class PlayheadProgressPublisherTests: XCTestCase {
+    var sut: Publishers.PlayheadProgressPublisher!
+    var player: MockAVPlayer!
+    var subscriptions = Set<AnyCancellable>()
+    
+    override func setUp() {
+        player = MockAVPlayer()
+        sut = Publishers.PlayheadProgressPublisher(player: player)
+    }
+    
+    override func tearDown() {
+        subscriptions = []
+    }
+    
+    func testWhenTimeIsUpdated_ItEmitsTheNewTime() {
+        var receivedTimes: [TimeInterval] = []
+        let expectedTimes: [TimeInterval] = [1]
+        sut.sink { time in
+            receivedTimes.append(time)
+        }
+        .store(in: &subscriptions)
+        
+        for time in expectedTimes {
+            player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        }
+        
+        XCTAssertEqual(receivedTimes, expectedTimes)
+    }
+    
+    func testWhenTimeIsUpdatedTwice_ItEmitsTheNewTimes() {
+        var receivedTimes: [TimeInterval] = []
+        let expectedTimes: [TimeInterval] = [1, 2]
+        sut.sink { time in
+            receivedTimes.append(time)
+        }
+        .store(in: &subscriptions)
+        
+        for time in expectedTimes {
+            player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        }
+        
+        XCTAssertEqual(receivedTimes, expectedTimes)
+    }
+    
+    func testWhenNoValuesAreRequested_ItCompletesImmediately() {
+        // given
+        let expectedValues: [TimeInterval] = []
+        var receivedValues: [TimeInterval] = []
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
+    func testWhenOnlyOneValueIsRequested_ItCompletesAfterEmittingOneValue() {
+        // given
+        let expectedValues: [TimeInterval] = [1]
+        var receivedValues: [TimeInterval] = []
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 1) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
+    func testWhenTwoValuesAreRequested_ItCompletesAfterEmittingTwoValues() {
+        // given
+        let expectedValues: [TimeInterval] = [1, 2]
+        var receivedValues: [TimeInterval] = []
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 2) { values in
+            receivedValues = values
+        }
+        
+        sut.subscribe(subscriber)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+}
+
+class MockAVPlayer: AVPlayer {
+    var updateClosure: ((CMTime) -> Void)?
+    
+    override func addPeriodicTimeObserver(forInterval interval: CMTime,
+                                          queue: DispatchQueue?,
+                                          using block: @escaping (CMTime) -> Void) -> Any {
+        updateClosure = block
+        return super.addPeriodicTimeObserver(forInterval: interval, queue: queue, using: block)
+    }
+}

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -139,8 +139,27 @@ class PlayheadProgressPublisherTests: XCTestCase {
     }
 }
 
+/// Mock AVPlayer implementation.
+///
+/// By overriding `AVPlayer.addPeriodicTimeObserver(forInterval:queue:using:)`
+/// it can capture the method's `block` parameter, which it can use to post arbitrary progress updates.
+///
 class MockAVPlayer: AVPlayer {
-    var updateClosure: ((CMTime) -> Void)?
+    /// Closure to use for posting an arbitrary progress update.
+    ///
+    /// Usage:
+    /// Subscribe to progress updates.
+    /// This will invoke `addPeriodicTimeObserver(forInterval:queue:using:)`
+    /// which allows the mock to capture the update closure:
+    /// ```
+    /// Publishers.PlayheadProgressPublisher(player: player).sink {}
+    /// ```
+    /// Then the mock can be used to post arbitrary progress updates:
+    /// ```
+    /// player.updateClosure?(10)
+    /// ```
+    ///
+    var updateClosure: ((_ time: CMTime) -> Void)?
     
     override func addPeriodicTimeObserver(forInterval interval: CMTime,
                                           queue: DispatchQueue?,

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -26,7 +26,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         subscriptions = []
     }
     
-    func testWhenTimeIsUpdated_ItEmitsTheNewTime() {
+    func testWhenDemandIsUnlimited_AndTimeIsUpdated_ItEmitsTheNewTime() {
         var receivedTimes: [TimeInterval] = []
         let expectedTimes: [TimeInterval] = [1]
         sut.sink { time in
@@ -41,7 +41,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedTimes, expectedTimes)
     }
     
-    func testWhenTimeIsUpdatedTwice_ItEmitsTheNewTimes() {
+    func testWhenDemandIsUnlimited_AndTimeIsUpdatedTwice_ItEmitsTheNewTimes() {
         var receivedTimes: [TimeInterval] = []
         let expectedTimes: [TimeInterval] = [1, 2]
         sut.sink { time in
@@ -56,7 +56,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedTimes, expectedTimes)
     }
     
-    func testWhenNoValuesAreRequested_ItEmitsNoValues() {
+    func testWhenDemandIsZero_ItEmitsNoValues() {
         // given
         let expectedValues: [TimeInterval] = []
         var receivedValues: [TimeInterval] = []
@@ -76,7 +76,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenValuesAreRequested_ItStartsEmittingValues() {
+    func testWhenInitialDemandIsZero_AndThenFiveValuesAreRequested_ItEmitsFiveValues() {
         // given
         let expectedValues: [TimeInterval] = [1, 2, 3, 4, 5]
         var receivedValues: [TimeInterval] = []
@@ -98,7 +98,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenOnlyOneValueIsRequested_ItCompletesAfterEmittingOneValue() {
+    func testWhenDemandIsOne_ItCompletesAfterEmittingOneValue() {
         // given
         let expectedValues: [TimeInterval] = [1]
         var receivedValues: [TimeInterval] = []
@@ -118,7 +118,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenTwoValuesAreRequested_ItCompletesAfterEmittingTwoValues() {
+    func testWhenDemandIsTwo_ItCompletesAfterEmittingTwoValues() {
         // given
         let expectedValues: [TimeInterval] = [1, 2]
         var receivedValues: [TimeInterval] = []

--- a/AVFoundation-CombineTests/TestSubscriber.swift
+++ b/AVFoundation-CombineTests/TestSubscriber.swift
@@ -23,6 +23,13 @@ class TestSubscriber<T>: Subscriber {
         self.onComplete = onComplete
     }
     
+    func startRequestingValues(_ demand: Int) {
+        guard let subscription = subscription else {
+            fatalError("requestValues(_:) may only be called after subscribing")
+        }
+        subscription.request(.max(demand))
+    }
+    
     func receive(subscription: Subscription) {
         self.subscription = subscription
         subscription.request(.max(demand))

--- a/AVFoundation-CombineTests/TestSubscriber.swift
+++ b/AVFoundation-CombineTests/TestSubscriber.swift
@@ -1,0 +1,40 @@
+//
+//  TestSubscriber.swift
+//  AVFoundation-CombineTests
+//
+//  Created by József Vesza on 2020. 07. 24..
+//  Copyright © 2020. József Vesza. All rights reserved.
+//
+
+import Combine
+
+class TestSubscriber<T>: Subscriber {
+    typealias Input = T
+    typealias Failure = Never
+    
+    let demand: Int
+    let onComplete: ([T]) -> Void
+    
+    private var receivedValues: [T] = []
+    private var subscription: Subscription? = nil
+    
+    init(demand: Int, onComplete: @escaping ([T]) -> Void) {
+        self.demand = demand
+        self.onComplete = onComplete
+    }
+    
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+        subscription.request(.max(demand))
+    }
+    
+    func receive(_ input: T) -> Subscribers.Demand {
+        receivedValues.append(input)
+        return .none
+    }
+    
+    func receive(completion: Subscribers.Completion<Never>) {
+        onComplete(receivedValues)
+        subscription = nil
+    }
+}


### PR DESCRIPTION
Fixes #6 

As it turns out, it was a good idea to introduce unit tests, because it helped me discover that I didn't update the demand correctly. The most notable change was this probably the following:
```swift
// previous implementation
self.requested -= .max(1)
_ = self.subscriber?.receive(time.seconds)
```
Notice how the return value of `receive` is unused, so even if the subscriber updates the demand, it's not taken into account. The solution was to update this to to add the new demand to the existing value:
```swift
let newDemand = subscriber.receive(newValue)
self.requested += newDemand
```

Another problem I discovered was that the publishers only completed when the subscriptions themselves were terminated. The following part took care of it:

```swift
// ...
let newDemand = subscriber.receive(newValue)
self.requested += newDemand
// if the new demand is `.none`, complete
if self.requested == .none {
    subscriber.receive(completion: .finished)
}
```

I've added unit tests to cover all these cases, and a test subscriber with adjustable demand to help.