### PR TITLE
Feature/is playback buffer empty publisher

### DIFF
--- a/AVFoundation-Combine/AVPlayer+Publishers.swift
+++ b/AVFoundation-Combine/AVPlayer+Publishers.swift
@@ -27,6 +27,7 @@ public extension AVPlayer {
     }
     
     /// Publisher for the `rate` property.
+    /// The current playback rate.
     /// - Returns: Publisher for the `rate` property.
     func ratePublisher() -> Publishers.PlayerRatePublisher {
         let keyPath: KeyPath<AVPlayer, Float> = \.rate
@@ -34,6 +35,7 @@ public extension AVPlayer {
     }
     
     /// Publisher for the `currentItem` property
+    /// The player’s current player item.
     /// - Returns: Publisher for the `currentItem` property
     func currentItemPublisher() -> AnyPublisher<AVPlayerItem?, Never> {
         let keyPath: KeyPath<AVPlayer, AVPlayerItem?> = \.currentItem
@@ -43,22 +45,32 @@ public extension AVPlayer {
     // MARK: AVPlayerItem Publishers
     
     /// Publisher for the `status` property in `AVPlayer.currentItem`
+    /// A status that indicates whether the player can be used for playback.
     /// - Returns: Publisher for the `status` property in `AVPlayer.currentItem`
     func statusPublisher() -> AnyPublisher<AVPlayerItem.Status, Never> {
         guard let currentItem = currentItem else {
             return Empty().eraseToAnyPublisher()
         }
-        let keyPath: KeyPath<AVPlayerItem, AVPlayerItem.Status> = \.status
-        return Publishers.KVObservingPublisher(observedObject: currentItem, keyPath: keyPath).eraseToAnyPublisher()
+        return currentItem.statusPublisher()
     }
     
     /// Publisher for the `isPlaybackLikelyToKeepUp` property in `AVPlayer.currentItem`
+    /// A Boolean value that indicates whether the item will likely play through without stalling.
     /// - Returns: Publisher for the `isPlaybackLikelyToKeepUp` property in `AVPlayer.currentItem`
     func isPlaybackLikelyToKeepUpPublisher() -> AnyPublisher<Bool, Never> {
         guard let currentItem = currentItem else {
             return Empty().eraseToAnyPublisher()
         }
-        let keyPath: KeyPath<AVPlayerItem, Bool> = \.isPlaybackLikelyToKeepUp
-        return Publishers.KVObservingPublisher(observedObject: currentItem, keyPath: keyPath).eraseToAnyPublisher()
+        return currentItem.isPlaybackLikelyToKeepUpPublisher()
+    }
+    
+    /// Publisher for the `isPlaybackBufferEmpty` property.
+    /// A Boolean value that indicates whether playback has consumed all buffered media and that playback will stall or end.
+    /// - Returns: Publisher for the `isPlaybackBufferEmpty` property.
+    func isPlaybackBufferEmptyPublisher() -> AnyPublisher<Bool, Never> {
+        guard let currentItem = currentItem else {
+            return Empty().eraseToAnyPublisher()
+        }
+        return currentItem.isPlaybackBufferEmptyPublisher()
     }
 }

--- a/AVFoundation-Combine/AVPlayerItem+Publishers.swift
+++ b/AVFoundation-Combine/AVPlayerItem+Publishers.swift
@@ -13,13 +13,23 @@ import AVKit
 public extension AVPlayerItem {
     
     /// Publisher for the `isPlaybackLikelyToKeepUp` property.
+    /// A Boolean value that indicates whether the item will likely play through without stalling.
     /// - Returns: Publisher for the `isPlaybackLikelyToKeepUp` property.
     func isPlaybackLikelyToKeepUpPublisher() -> Publishers.PlayerItemIsPlaybackLikelyToKeepUpPublisher {
         let keyPath: KeyPath<AVPlayerItem, Bool> = \.isPlaybackLikelyToKeepUp
         return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath)
     }
     
+    /// Publisher for the `isPlaybackBufferEmpty` property.
+    /// A Boolean value that indicates whether playback has consumed all buffered media and that playback will stall or end.
+    /// - Returns: Publisher for the `isPlaybackBufferEmpty` property.
+    func isPlaybackBufferEmptyPublisher() -> AnyPublisher<Bool, Never> {
+        let keyPath: KeyPath<AVPlayerItem, Bool> = \.isPlaybackBufferEmpty
+        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath).eraseToAnyPublisher()
+    }
+    
     /// Publisher for the `status` property.
+    /// The status of the player item.
     /// - Returns: Publisher for the `status` property.
     func statusPublisher() -> Publishers.PlayerItemStatusPublisher {
         let keyPath: KeyPath<AVPlayerItem, AVPlayerItem.Status> = \.status

--- a/AVFoundation-Combine/AVPlayerItem+Publishers.swift
+++ b/AVFoundation-Combine/AVPlayerItem+Publishers.swift
@@ -15,9 +15,9 @@ public extension AVPlayerItem {
     /// Publisher for the `isPlaybackLikelyToKeepUp` property.
     /// A Boolean value that indicates whether the item will likely play through without stalling.
     /// - Returns: Publisher for the `isPlaybackLikelyToKeepUp` property.
-    func isPlaybackLikelyToKeepUpPublisher() -> Publishers.PlayerItemIsPlaybackLikelyToKeepUpPublisher {
+    func isPlaybackLikelyToKeepUpPublisher() -> AnyPublisher<Bool, Never> {
         let keyPath: KeyPath<AVPlayerItem, Bool> = \.isPlaybackLikelyToKeepUp
-        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath)
+        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath).eraseToAnyPublisher()
     }
     
     /// Publisher for the `isPlaybackBufferEmpty` property.
@@ -29,10 +29,10 @@ public extension AVPlayerItem {
     }
     
     /// Publisher for the `status` property.
-    /// The status of the player item.
+    /// A status that indicates whether the player can be used for playback.
     /// - Returns: Publisher for the `status` property.
-    func statusPublisher() -> Publishers.PlayerItemStatusPublisher {
+    func statusPublisher() -> AnyPublisher<AVPlayerItem.Status, Never> {
         let keyPath: KeyPath<AVPlayerItem, AVPlayerItem.Status> = \.status
-        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath)
+        return Publishers.KVObservingPublisher(observedObject: self, keyPath: keyPath).eraseToAnyPublisher()
     }
 }

--- a/AVFoundation-Combine/ViewController.swift
+++ b/AVFoundation-Combine/ViewController.swift
@@ -14,6 +14,10 @@ import Combine
 class ViewController: AVPlayerViewController {
     
     /// A sample video URL
+    ///
+    /// **Big Buck Bunny (2008)**
+    ///
+    /// A recently awoken enormous and utterly adorable fluffy rabbit is heartlessly harassed by a flying squirrel's gang of rodents who are determined to squash his happiness.
     private let videoURL = URL(string: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")!
     
     /// A set to store all our Publisher susbcriptions
@@ -21,21 +25,56 @@ class ViewController: AVPlayerViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let player = AVPlayer()
+        player = AVPlayer()
         
-        player.currentItemPublisher()
-            .sink { item in
+        player?.currentItemPublisher()
+            .sink {[weak self] item in
                 print(">> current item: \(String(describing: item))")
-            }
-            .store(in: &subscriptions)
+                if item != nil {
+                    self?.subscribeToPlayerItemPublishers()
+                }
+        }
+        .store(in: &subscriptions)
         
-        player.playheadProgressPublisher()
+        player?.playheadProgressPublisher()
             .sink { (time) in
                 print(">> received playhead progress: \(time)")
-            }
-            .store(in: &subscriptions)
+        }
+        .store(in: &subscriptions)
         
-        player.statusPublisher()
+        player?.ratePublisher()
+            .sink { (rate) in
+                print("rate changed:")
+                switch rate {
+                case 0.0:
+                    print(">> paused")
+                case 1.0:
+                    print(">> playing")
+                default:
+                    print(">> \(rate)")
+                }
+        }
+        .store(in: &subscriptions)
+        
+        // Load our sample video
+        player?.replaceCurrentItem(with: AVPlayerItem(url: videoURL))
+        
+    }
+    
+    private func subscribeToPlayerItemPublishers() {
+        player?.isPlaybackLikelyToKeepUpPublisher()
+            .sink {isPlaybackLikelyToKeepUp in
+                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
+        }
+        .store(in: &subscriptions)
+        
+        player?.isPlaybackBufferEmptyPublisher()
+            .sink {isPlaybackBufferEmpty in
+                print(">> isPlaybackBufferEmpty \(isPlaybackBufferEmpty) ")
+        }
+        .store(in: &subscriptions)
+        
+        player?.statusPublisher()
             .sink { status in
                 print("received status:")
                 switch status {
@@ -48,32 +87,8 @@ class ViewController: AVPlayerViewController {
                 @unknown default:
                     print(">> other")
                 }
-            }
-            .store(in: &subscriptions)
-        
-        player.ratePublisher()
-            .sink { (rate) in
-                print("rate changed:")
-                switch rate {
-                case 0.0:
-                    print(">> paused")
-                case 1.0:
-                    print(">> playing")
-                default:
-                    print(">> \(rate)")
-                }
-            }
-            .store(in: &subscriptions)
-        
-        player.isPlaybackLikelyToKeepUpPublisher()
-            .sink {isPlaybackLikelyToKeepUp in
-                print(">> isPlaybackLikelyToKeepUp \(isPlaybackLikelyToKeepUp) ")
-            }
-            .store(in: &subscriptions)
-        
-        // Load our sample video
-        player.replaceCurrentItem(with: AVPlayerItem(url: videoURL))
-        self.player = player
+        }
+        .store(in: &subscriptions)
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The purpose of this project is to add Combine wrappers around AVFoundation (spec
 ## Publishers
 All publishers are designed to be lazy: they only start observing AVPlayer's properties when subscribed to.
 
-### `PlayheadProgressPublisher`
-`PlayheadProgressPublisher` will emit an event whenever the player's playhead updates. It may be used to update a custom progress indicator.
+### `playheadProgressPublisher`
+`playheadProgressPublisher` will emit an event whenever the player's playhead updates. It may be used to update a custom progress indicator.
 ```swift
 player.playheadProgressPublisher()
     .sink { (time) in
@@ -16,8 +16,8 @@ player.playheadProgressPublisher()
     .store(in: &subscriptions)
 ```
 
-### `PlayerRatePublisher`
-`PlayerRatePublisher` will emit an event whenever the rate of the observed player changes. It can be useful to present custom UI when the player is paused, or fast-forwarding/rewinding. (see https://developer.apple.com/documentation/avfoundation/avplayer/1388846-rate)
+### `ratePublisher`
+`AVPlayer.ratePublisher` will emit an event whenever the rate of the observed player changes. It can be useful to present custom UI when the player is paused, or fast-forwarding/rewinding. (see https://developer.apple.com/documentation/avfoundation/avplayer/1388846-rate)
 ```swift
 player.ratePublisher()
     .sink { (rate) in
@@ -34,8 +34,8 @@ player.ratePublisher()
     .store(in: &subscriptions)
 ```
 
-### `PlayerItemStatusPublisher`
-`PlayerItemStatusPublisher` will emit an event when the status of the player's `playerItem` changes. It can be useful to defer work until the item is ready to play. (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1389493-status)
+### `AVPlayer.statusPublisher`
+`AVPlayer.statusPublisher` will emit an event when the status of the player's `playerItem` changes. It can be useful to defer work until the item is ready to play. (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1389493-status)
 
 ```swift
 player.statusPublisher()
@@ -55,10 +55,10 @@ player.statusPublisher()
     .store(in: &subscriptions)
 ```
 
-`PlayerItemStatusPublisher` is also available as `AVPlayerItem.statusPublisher()`.
+`AVPlayer.statusPublisher` is also available as `AVPlayerItem.statusPublisher()`.
 
-### `PlayerItemIsPlaybackLikelyToKeepUpPublisher`
-`PlayerItemIsPlaybackLikelyToKeepUpPublisher` will emit an event when the value of `isPlaybackLikelyToKeepUpPublisher` in the player's `playerItem` changes. This property communicates a prediction of playability. (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1390348-isplaybacklikelytokeepup)
+### `isPlaybackLikelyToKeepUpPublisher`
+`AVPlayer.isPlaybackLikelyToKeepUpPublisher` will emit an event when the value of `isPlaybackLikelyToKeepUpPublisher` in the player's `playerItem` changes. This property communicates a prediction of playability. (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1390348-isplaybacklikelytokeepup)
 
 ```swift
 player.isPlaybackLikelyToKeepUpPublisher()
@@ -68,4 +68,17 @@ player.isPlaybackLikelyToKeepUpPublisher()
     .store(in: &subscriptions)
 ```
 
-`PlayerItemIsPlaybackLikelyToKeepUpPublisher` is also available as `AVPlayerItem.isPlaybackLikelyToKeepUpPublisher()`.
+`AVPlayer.isPlaybackBufferEmptyPublisher` is also available as `AVPlayerItem.isPlaybackLikelyToKeepUpPublisher()`.
+
+### `isPlaybackBufferEmptyPublisher`
+`isPlaybackBufferEmptyPublisher` will emit an event when the value of `isPlaybackBufferEmptyPublisher` in the player's `playerItem` changes. This property is a Boolean value that indicates whether playback has consumed all buffered media and that playback will stall or end. (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1386960-isplaybackbufferempty)
+
+```swift
+player?.isPlaybackBufferEmptyPublisher()
+    .sink {isPlaybackBufferEmpty in
+        print(">> isPlaybackBufferEmpty \(isPlaybackBufferEmpty) ")
+    }
+    .store(in: &subscriptions)
+```
+
+`AVPlayer.isPlaybackBufferEmptyPublisher()` is also available as `AVPlayerItem.isPlaybackBufferEmptyPublisher()`.


### PR DESCRIPTION
This PR adds `isPlaybackBufferEmptyPublisher` both on `AVPlayerItem` and `AVPlayer`.

Along the way in noticed that some Publishers were not type erased properly (Fixes #3)

Small modifications were made to the sample `ViewController` and the README