### PR TITLE
Add tests for adjusting the demand on the fly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator,OS=13.0,name=iPhone 11']
+          destination: ['platform=iOS Simulator, name=iPhone 11']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,9 @@ jobs:
   test:
     name: Test
     runs-on: macOS-latest
-    strategy:
-        matrix:
-          destination: "platform=iOS Simulator,name=iPhone 11"
     steps:
       - name: Checkout
         uses: actions/checkout@master
       - name: Build and test
         run: |
-          xcodebuild clean test -project AVFoundation-Combine.xcodeproj -scheme AVFoundation-Combine -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-        env:
-         destination: ${{ matrix.destination }}
+          xcodebuild clean test -project AVFoundation-Combine.xcodeproj -scheme AVFoundation-Combine -destination platform=iOS Simulator,name=iPhone 11 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator, name=iPhone 11']
+          destination: "platform=iOS Simulator,name=iPhone 11"
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,4 +9,4 @@ jobs:
         uses: actions/checkout@master
       - name: Build and test
         run: |
-          xcodebuild clean test -project AVFoundation-Combine.xcodeproj -scheme AVFoundation-Combine -destination platform=iOS Simulator,name=iPhone 11 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+          xcodebuild clean test -project AVFoundation-Combine.xcodeproj -scheme AVFoundation-Combine -destination "platform=iOS Simulator,name=iPhone 11" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -137,6 +137,27 @@ class PlayheadProgressPublisherTests: XCTestCase {
         // then
         XCTAssertEqual(receivedValues, expectedValues)
     }
+    
+    func testWhenInitialDemandIsOne_AndAnAdditionalValueIsRequested_ItEmitsTwoValues() {
+        // given
+        let expectedValues: [TimeInterval] = [1, 2]
+        var receivedValues: [TimeInterval] = []
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 1, onValueReceived: { value in
+            return value == 1 ? 1 : 0
+        }, onComplete: { values in
+            receivedValues = values
+        })
+        sut.subscribe(subscriber)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        timeUpdates.forEach { time in player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC))) }
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
 }
 
 /// Mock AVPlayer implementation.


### PR DESCRIPTION
While working on a summary about the topics covered in this project, I've noticed a gap in our testing: a Subscriber may update the demand when receiving a value via `receive(_:)`, and this scenario was never tested.

I added a hook for tests to allow updating the demand, and wrote a new unit test to verify the behavior.