### PR TITLE
Update completion behavior

### DIFF
--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -51,14 +51,10 @@ public extension Publishers {
             
             let interval = CMTime(seconds: self.interval, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
             timeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: DispatchQueue.main) { [weak self] time in
-                guard let self = self, let subscriber = self.subscriber else { return }
+                guard let self = self, let subscriber = self.subscriber, self.requested > .none else { return }
                 self.requested -= .max(1)
                 let newDemand = subscriber.receive(time.seconds)
                 self.requested += newDemand
-                
-                if self.requested == .none {
-                    subscriber.receive(completion: .finished)
-                }
             }
         }
         

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -61,8 +61,9 @@ class PlayheadProgressPublisherTests: XCTestCase {
         let expectedValues: [TimeInterval] = []
         var receivedValues: [TimeInterval] = []
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { values in
-            receivedValues = values
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { value in
+            receivedValues.append(value)
+            return 0
         }
         
         sut.subscribe(subscriber)
@@ -81,8 +82,9 @@ class PlayheadProgressPublisherTests: XCTestCase {
         let expectedValues: [TimeInterval] = [1, 2, 3, 4, 5]
         var receivedValues: [TimeInterval] = []
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { values in
-            receivedValues = values
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { value in
+            receivedValues.append(value)
+            return 0
         }
         
         sut.subscribe(subscriber)
@@ -98,13 +100,14 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenDemandIsOne_ItCompletesAfterEmittingOneValue() {
+    func testWhenDemandIsOne_ItEmitsOneValue() {
         // given
         let expectedValues: [TimeInterval] = [1]
         var receivedValues: [TimeInterval] = []
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 1) { values in
-            receivedValues = values
+        let subscriber = TestSubscriber<TimeInterval>(demand: 1) { value in
+            receivedValues.append(value)
+            return 0
         }
         
         sut.subscribe(subscriber)
@@ -118,13 +121,14 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
-    func testWhenDemandIsTwo_ItCompletesAfterEmittingTwoValues() {
+    func testWhenDemandIsTwo_ItEmitsTwoValues() {
         // given
         let expectedValues: [TimeInterval] = [1, 2]
         var receivedValues: [TimeInterval] = []
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 2) { values in
-            receivedValues = values
+        let subscriber = TestSubscriber<TimeInterval>(demand: 2) { value in
+            receivedValues.append(value)
+            return 0
         }
         
         sut.subscribe(subscriber)
@@ -143,11 +147,11 @@ class PlayheadProgressPublisherTests: XCTestCase {
         let expectedValues: [TimeInterval] = [1, 2]
         var receivedValues: [TimeInterval] = []
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 1, onValueReceived: { value in
+        let subscriber = TestSubscriber<TimeInterval>(demand: 1) { value in
+            receivedValues.append(value)
             return value == 1 ? 1 : 0
-        }, onComplete: { values in
-            receivedValues = values
-        })
+        }
+        
         sut.subscribe(subscriber)
         
         let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -81,7 +81,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
         // given
         var completed = false
         
-        let subscriber = TestSubscriber<TimeInterval>(demand: 0, onComplete: { _ in
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0, onComplete: {
             completed = true
         })
         

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -77,6 +77,21 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
+    func testWhenDemandIsZero_ItDoesNotCompleteImmediately() {
+        // given
+        var completed = false
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0, onComplete: { _ in
+            completed = true
+        })
+        
+        // when
+        sut.subscribe(subscriber)
+        
+        // then
+        XCTAssertFalse(completed)
+    }
+    
     func testWhenInitialDemandIsZero_AndThenFiveValuesAreRequested_ItEmitsFiveValues() {
         // given
         let expectedValues: [TimeInterval] = [1, 2, 3, 4, 5]

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -178,6 +178,28 @@ class PlayheadProgressPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValues, expectedValues)
     }
     
+    func testWhenInitialDemandIsOne_AndNoMoreValuesAreRequested_ThenMoreValuesAreRequested_ItEmitsMoreValues() {
+        // given
+        let expectedValues: [TimeInterval] = [1, 3]
+        var receivedValues: [TimeInterval] = []
+
+        let subscriber = TestSubscriber<TimeInterval>(demand: 1) { value in
+            receivedValues.append(value)
+            return 0
+        }
+        
+        sut.subscribe(subscriber)
+        player.updateClosure?(CMTime(seconds: 1, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        player.updateClosure?(CMTime(seconds: 2, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        
+        // when
+        subscriber.startRequestingValues(1)
+        player.updateClosure?(CMTime(seconds: 3, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        
+        // then
+        XCTAssertEqual(receivedValues, expectedValues)
+    }
+    
     func testWhenSubscriptionIsCancelled_ItStopsObservingThePlayback() {
         // given
         let subscription = sut.sink(receiveCompletion: { _ in }, receiveValue: { _ in  })

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -200,11 +200,18 @@ class MockAVPlayer: AVPlayer {
     /// ```
     ///
     var updateClosure: ((_ time: CMTime) -> Void)?
+    /// A flag to check if the time observer is invalidated upon cancellation
+    var timeObserverRemoved = false
     
     override func addPeriodicTimeObserver(forInterval interval: CMTime,
                                           queue: DispatchQueue?,
                                           using block: @escaping (CMTime) -> Void) -> Any {
         updateClosure = block
         return super.addPeriodicTimeObserver(forInterval: interval, queue: queue, using: block)
+    }
+    
+    override func removeTimeObserver(_ observer: Any) {
+        timeObserverRemoved = true
+        super.removeTimeObserver(observer)
     }
 }

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -177,6 +177,17 @@ class PlayheadProgressPublisherTests: XCTestCase {
         // then
         XCTAssertEqual(receivedValues, expectedValues)
     }
+    
+    func testWhenSubscriptionIsCancelled_ItStopsObservingThePlayback() {
+        // given
+        let subscription = sut.sink(receiveCompletion: { _ in }, receiveValue: { _ in  })
+        
+        // when
+        subscription.cancel()
+        
+        // then
+        XCTAssertTrue(player.timeObserverRemoved)
+    }
 }
 
 /// Mock AVPlayer implementation.

--- a/AVFoundation-CombineTests/TestSubscriber.swift
+++ b/AVFoundation-CombineTests/TestSubscriber.swift
@@ -14,22 +14,20 @@ class TestSubscriber<T>: Subscriber {
     typealias Failure = Never
     
     private let demand: Int
-    private let onComplete: ([T]) -> Void
+    private let onComplete: () -> Void
     private let onValueReceived: (T) -> Int
-    
-    private var receivedValues: [T] = []
+
     private var subscription: Subscription? = nil
     
     /// Initializes a `TestSubscriber` instance
     /// - Parameters:
     ///   - demand: the amount of values to demand from the Publisher
     ///   - onComplete: a closure to invoke when the subscription completes.
-    ///   - receivedValues: array containing the values received by the Subscriber before completion
     ///   - onValueReceived: a closure to invoke when the subscription emits a value. Use this method to alter the demand.
     ///   - receivedValue: the value emitted by the Publisher
     ///
     init(demand: Int,
-         onComplete: @escaping (_ receivedValues: [T]) -> Void = { _ in  },
+         onComplete: @escaping () -> Void = {},
          onValueReceived: @escaping (_ receivedValue: T) -> Int = { _ in return 0 }) {
         self.demand = demand
         self.onComplete = onComplete
@@ -64,13 +62,12 @@ class TestSubscriber<T>: Subscriber {
     }
     
     func receive(_ input: T) -> Subscribers.Demand {
-        receivedValues.append(input)
         let newDemand = onValueReceived(input)
         return .max(newDemand)
     }
     
     func receive(completion: Subscribers.Completion<Never>) {
-        onComplete(receivedValues)
+        onComplete()
         // If the Subscription completes, the Subscriber must nil out its reference to it so that it can be released from memory.
         subscription = nil
     }

--- a/AVFoundation-CombineTests/TestSubscriber.swift
+++ b/AVFoundation-CombineTests/TestSubscriber.swift
@@ -29,8 +29,8 @@ class TestSubscriber<T>: Subscriber {
     ///   - receivedValue: the value emitted by the Publisher
     ///
     init(demand: Int,
-         onValueReceived: @escaping (_ receivedValue: T) -> Int = { _ in return 0 },
-         onComplete: @escaping (_ receivedValues: [T]) -> Void) {
+         onComplete: @escaping (_ receivedValues: [T]) -> Void = { _ in  },
+         onValueReceived: @escaping (_ receivedValue: T) -> Int = { _ in return 0 }) {
         self.demand = demand
         self.onComplete = onComplete
         self.onValueReceived = onValueReceived


### PR DESCRIPTION
As I continue to learn about how publishers should work, I had this feeling that a publisher shouldn't complete if the demand drops to zero.

If it completes, it can only start producing values again if we re-subscribe which is not what the callers would expect. To validate my suspicion I tested a few built-in publishers with a custom subscriber, and they don't complete either.

This change also enables our publisher to work with a pausable sink (such as our TestSubscriber) without the need to resubscribe