### PR TITLE
Prevent data race when requesting values from the publisher

### DIFF
--- a/AVFoundation-Combine.xcodeproj/xcshareddata/xcschemes/AVFoundation-Combine.xcscheme
+++ b/AVFoundation-Combine.xcodeproj/xcshareddata/xcschemes/AVFoundation-Combine.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      enableThreadSanitizer = "YES">
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-UNITTEST"

--- a/AVFoundation-Combine.xcodeproj/xcshareddata/xcschemes/AVFoundation-Combine.xcscheme
+++ b/AVFoundation-Combine.xcodeproj/xcshareddata/xcschemes/AVFoundation-Combine.xcscheme
@@ -26,7 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-UNITTEST"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AVFoundation-Combine/Info.plist
+++ b/AVFoundation-Combine/Info.plist
@@ -33,8 +33,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/AVFoundation-Combine/Supporting Files/SceneDelegate.swift
+++ b/AVFoundation-Combine/Supporting Files/SceneDelegate.swift
@@ -12,12 +12,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
+    var isUnitTesting: Bool {
+        return ProcessInfo.processInfo.arguments.contains("-UNITTEST")
+    }
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard !isUnitTesting,   
+            let windowScene = (scene as? UIWindowScene),
+            let rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() else { return }
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = rootViewController
+        window.makeKeyAndVisible()
+        self.window = window
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -237,10 +237,8 @@ class PlayheadProgressPublisherTests: XCTestCase {
         
         _ = group.wait(timeout: DispatchTime.now() + 5)
         
-        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
-        
         // when
-        timeUpdates.forEach { time in
+        (1...requestCount).map { TimeInterval($0) }.forEach { time in
             player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
         }
         

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -224,12 +224,11 @@ class PlayheadProgressPublisherTests: XCTestCase {
         
         sut.subscribe(subscriber)
         
-        let deadline = DispatchTime.now() + 0.5
         let group = DispatchGroup()
         
         for _ in 0..<requestCount {
             group.enter()
-            DispatchQueue.global().asyncAfter(deadline: deadline) {
+            DispatchQueue.global().async {
                 subscriber.startRequestingValues(1)
                 group.leave()
             }

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -210,6 +210,43 @@ class PlayheadProgressPublisherTests: XCTestCase {
         // then
         XCTAssertTrue(player.timeObserverRemoved)
     }
+    
+    func testWhenValuesAreRequestedFromMultipleThreads_RequestsAreSerialized() {
+        // given
+        let requestCount = 1000
+        let expectation = XCTestExpectation(description: "\(requestCount) values should be received")
+        expectation.expectedFulfillmentCount = requestCount
+        
+        let subscriber = TestSubscriber<TimeInterval>(demand: 0) { _ in
+            expectation.fulfill()
+            return 0
+        }
+        
+        sut.subscribe(subscriber)
+        
+        let deadline = DispatchTime.now() + 0.5
+        let group = DispatchGroup()
+        
+        for _ in 0..<requestCount {
+            group.enter()
+            DispatchQueue.global().asyncAfter(deadline: deadline) {
+                subscriber.startRequestingValues(1)
+                group.leave()
+            }
+        }
+        
+        _ = group.wait(timeout: DispatchTime.now() + 5)
+        
+        let timeUpdates: [TimeInterval] = [1, 2, 3, 4, 5]
+        
+        // when
+        timeUpdates.forEach { time in
+            player.updateClosure?(CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        }
+        
+        // then
+        wait(for: [expectation], timeout: 5)
+    }
 }
 
 /// Mock AVPlayer implementation.
@@ -240,7 +277,7 @@ class MockAVPlayer: AVPlayer {
                                           queue: DispatchQueue?,
                                           using block: @escaping (CMTime) -> Void) -> Any {
         updateClosure = block
-        return super.addPeriodicTimeObserver(forInterval: interval, queue: queue, using: block)
+        return super.addPeriodicTimeObserver(forInterval: interval, queue: queue, using: { _ in })
     }
     
     override func removeTimeObserver(_ observer: Any) {


### PR DESCRIPTION
I got some [feedback](https://www.reddit.com/r/iOSProgramming/comments/i1pmfd/combine_publishers_part_1_creating_a_publisher/g079tio/) about the blog post, so I decided to take a look at potential race conditions.

After digging a bit (there's not much documentation on Combine and concurrency), I found some [rules to follow](https://forums.swift.org/t/thread-safety-for-combine-publishers/29491/11) on the Swift forums:

> 1. A call to receive(subscriber:) (the implementation-required method) can come from any thread
> 2. "Downstream" calls to Subscriber's receive(subscription:), receive(_:), and receive(completion:) must be serialized (but may be on different threads)
> 3. "Upstream" calls to Subscription's request(_:) and cancel() must be serialized (but may be on different threads)

Let's look at them one by one:
1. No action required. When the publisher receives a new subscriber, it creates a new subscription anytime, so it's safe.
2. This is the case when our publisher emits values to the subscriber. The underlying time observer it's using already emits values on the main thread, serially, so this is taken care of.
3. This is where I spent most of my time: `request(_:)` can be called multiple times on the publisher, and from any thread, so it seemed to be a good idea to cover.

To catch it, (I know it's a bit contrived), I implemented a test, which requests 1000 values, all from different threads. If there's no data race, all 1000 values should arrive. If there's a data race, sometimes, some of the requests could end up being lost along the way (due to the random order of events), resulting in <1000 values being served.

To further help in debugging, I enabled the Thread Sanitizer for unit tests, which helps in catching data races. And after running the test, it immediately flagged it.

<img width="891" alt="Screenshot 2020-08-07 at 16 27 22" src="https://user-images.githubusercontent.com/2749464/89656330-bb445600-d8cb-11ea-8780-94b355e4d925.png">

I chose to use a queue to serialize the requests. There are other locking mechanisms as well, but using GCD is pretty straightforward, and readable, so I settled at that.

I also took a look at serializing `cancel` but I couldn't come up with a scenario in which it would misbehave, so I shelved it for now.

To verify the data race, just change the following lines:
```swift
func request(_ demand: Subscribers.Demand) {
    queue.sync {
        processDemand(demand)
    }
}
```
into
```swift
func request(_ demand: Subscribers.Demand) {
    processDemand(demand)
}
```
and run the unit tests.

I added an additional improvement: by default, the app gets launched normally during unit tests. In our case it means that video playback is started which makes it harder to debug tests (some breakpoints get hit because the regular app is also using the publisher). To solve this, I updated the launch sequence (in the scene delegate) to not load the main view when unit testing. 