### PR TITLE
Apply locking on sending values and cancellation

### DIFF
--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -69,7 +69,6 @@ public extension Publishers {
                 requested -= .max(1)
                 let newDemand = subscriber.receive(time.seconds)
                 requested += newDemand
-                print("value sent: \(time.seconds), new demand: \(requested)")
             }
         }
         

--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -74,11 +74,13 @@ public extension Publishers {
         }
         
         func cancel() {
-            if let timeObserverToken = timeObserverToken {
-                player.removeTimeObserver(timeObserverToken)
+            withLock {
+                if let timeObserverToken = timeObserverToken {
+                    player.removeTimeObserver(timeObserverToken)
+                }
+                timeObserverToken = nil
+                subscriber = nil
             }
-            timeObserverToken = nil
-            subscriber = nil
         }
         
         private func withLock(_ operation: () -> Void) {

--- a/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
+++ b/AVFoundation-CombineTests/PlayheadProgressPublisherTests.swift
@@ -266,7 +266,7 @@ class PlayheadProgressPublisherTests: XCTestCase {
             group.leave()
         }
         
-        self.player.updateClosure?(CMTime(seconds: TimeInterval(1), preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        player.updateClosure?(CMTime(seconds: TimeInterval(1), preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
         
         _ = group.wait(timeout: DispatchTime.now() + 5)
         


### PR DESCRIPTION
Following up on my concurrency journey I applied locks on sending values and cancellation.

I initially started with a queue, but `queue.sync` could end up deadlocking when `processDemand(_:)` and `sendValue(_:)` are executed from different threads. To fix that, I needed to move to `queue.async`, but using that just starts to get uncomfortable. So I changed the implementation to work with a recursive lock, which supports locking multiple times without a deadlock. Another added benefit is that the lock is synchronous, so it's a bit more straightforward.

I came up with a test that invokes `processDemand(_:)` and `sendValue(_:)` from different threads, and without the locking, it triggered the Thread sanitizer (both code paths modify `requested`):

<img width="1392" alt="Screenshot 2020-08-07 at 22 42 57" src="https://user-images.githubusercontent.com/2749464/89703018-35fe8700-d947-11ea-997f-90fb279d79ff.png">
<img width="1392" alt="Screenshot 2020-08-07 at 22 42 53" src="https://user-images.githubusercontent.com/2749464/89703020-39920e00-d947-11ea-800f-0ce931db556b.png">

I don't think this test case is super valuable for testing the logic of the publisher, but it causes enough chaos for threading issues to come up.

I also tried coming up with a test for cancellation, but I couldn't get the conditions right. I see however how it could cause an issue:
* when the progress updates, `sendValue(_:)` is invoked, which reads the value of `subscriber`
* when the subscription is cancelled, it writes the value of `subscriber` as it is nilled out

Although non-deterministic (as most of these issues are), there could be a scenario where these methods are invoked from different threads, and as they both access the same variable, a data race may occur. So to be on the safe side, I applied locking on cancellation as well.

With these changes I think the publisher is as thread-safe as it can be, and all of the [thread safety rules](https://forums.swift.org/t/thread-safety-for-combine-publishers/29491/11) are checked.
