### PR TITLE
Updates comments

### DIFF
--- a/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
+++ b/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
@@ -15,21 +15,18 @@ public extension AVPlayer {
     // MARK: - AVPlayer Publishers
     
     /// Publisher tracking playhead progress updates on `AVPlayer`
-    /// - Returns: Publisher tracking playhead progress updates on `AVPlayer`
+    /// - Seealso: `Publishers.PlayheadProgressPublisher`
+    /// - Parameter interval: The interval at which the underlying playhead observer executes an update
     func playheadProgressPublisher(interval: TimeInterval = 0.25) -> AnyPublisher<TimeInterval, Never> {
         Publishers.PlayheadProgressPublisher(interval: interval, player: self).eraseToAnyPublisher()
     }
     
-    /// Publisher for the `rate` property.
-    /// The current playback rate.
-    /// - Returns: Publisher for the `rate` property.
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `rate` property
     func ratePublisher() -> AnyPublisher<Float, Never> {
         publisher(for: \.rate).eraseToAnyPublisher()
     }
     
-    /// Publisher for the `currentItem` property
-    /// The player’s current player item.
-    /// - Returns: Publisher for the `currentItem` property
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `currentItem` property
     func currentItemPublisher() -> AnyPublisher<AVPlayerItem?, Never> {
          publisher(for: \.currentItem).eraseToAnyPublisher()
     }

--- a/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
+++ b/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
@@ -15,8 +15,8 @@ public extension AVPlayer {
     // MARK: - AVPlayer Publishers
     
     /// Publisher tracking playhead progress updates on `AVPlayer`
-    /// - Seealso: `Publishers.PlayheadProgressPublisher`
     /// - Parameter interval: The interval at which the underlying playhead observer executes an update
+    /// - SeeAlso: `Publishers.PlayheadProgressPublisher`
     func playheadProgressPublisher(interval: TimeInterval = 0.25) -> AnyPublisher<TimeInterval, Never> {
         Publishers.PlayheadProgressPublisher(interval: interval, player: self).eraseToAnyPublisher()
     }

--- a/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
+++ b/AVFoundation-Combine/Extensions/AVPlayer+Publishers.swift
@@ -16,7 +16,10 @@ public extension AVPlayer {
     
     /// Publisher tracking playhead progress updates on `AVPlayer`
     /// - Parameter interval: The interval at which the underlying playhead observer executes an update
-    /// - SeeAlso: `Publishers.PlayheadProgressPublisher`
+    ///
+    /// # SeeAlso:
+    /// `Publishers.PlayheadProgressPublisher`
+    ///
     func playheadProgressPublisher(interval: TimeInterval = 0.25) -> AnyPublisher<TimeInterval, Never> {
         Publishers.PlayheadProgressPublisher(interval: interval, player: self).eraseToAnyPublisher()
     }

--- a/AVFoundation-Combine/Extensions/AVPlayerItem+Publishers.swift
+++ b/AVFoundation-Combine/Extensions/AVPlayerItem+Publishers.swift
@@ -12,35 +12,27 @@ import AVKit
 
 public extension AVPlayerItem {
     
-    /// Publisher for the `isPlaybackLikelyToKeepUp` property.
-    /// A Boolean value that indicates whether the item will likely play through without stalling.
-    /// - Returns: Publisher for the `isPlaybackLikelyToKeepUp` property.
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `isPlaybackLikelyToKeepUp` property
     func isPlaybackLikelyToKeepUpPublisher() -> AnyPublisher<Bool, Never> {
         publisher(for: \.isPlaybackLikelyToKeepUp).eraseToAnyPublisher()
     }
     
-    /// Publisher for the `isPlaybackBufferEmpty` property.
-    /// A Boolean value that indicates whether playback has consumed all buffered media and that playback will stall or end.
-    /// - Returns: Publisher for the `isPlaybackBufferEmpty` property.
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `isPlaybackBufferEmpty` property
     func isPlaybackBufferEmptyPublisher() -> AnyPublisher<Bool, Never> {
         publisher(for: \.isPlaybackBufferEmpty).eraseToAnyPublisher()
     }
     
-    /// Publisher for the `status` property.
-    /// A status that indicates whether the player can be used for playback.
-    /// - Returns: Publisher for the `status` property.
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `status` property
     func statusPublisher() -> AnyPublisher<AVPlayerItem.Status, Never> {
         publisher(for: \.status).eraseToAnyPublisher()
     }
     
-    /// Publisher for the `duration` property
+    /// Wrapper around a `NSObject.KeyValueObservingPublisher` for the `duration` property
     func durationPublisher() -> AnyPublisher<CMTime, Never> {
         publisher(for: \.duration).eraseToAnyPublisher()
     }
     
-    /// Publisher that wraps `Notification.Name.AVPlayerItemDidPlayToEndTime`
-    ///
-    /// - Returns: Publisher that emits a value  when the item plays to its end time.
+    /// Wrapper around a `NotificationCenter.Publisher` that emits values for `.AVPlayerItemDidPlayToEndTime`
     func didPlayToEndTimePublisher(_ notificationCenter: NotificationCenter = .default) -> AnyPublisher<Notification, Never> {
         notificationCenter
             .publisher(for: .AVPlayerItemDidPlayToEndTime, object: self)

--- a/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
+++ b/AVFoundation-Combine/Publishers/PlayheadProgressPublisher.swift
@@ -11,6 +11,7 @@ import Combine
 import AVKit
 
 public extension Publishers {
+    /// Custom `Publisher` implementation that wraps `AVPlayer.addPeriodicTimeObserver(forInterval:queue:using)` to emit values corresponding to the playhead's progress
     struct PlayheadProgressPublisher: Publisher {
         public typealias Output = TimeInterval
         public typealias Failure = Never
@@ -18,6 +19,10 @@ public extension Publishers {
         private let interval: TimeInterval
         private let player: AVPlayer
         
+        /// Initializes `PlayheadProgressPublisher`tracking the playhead's progress of a given `AVPlayer` instance at a given interval.
+        /// - Parameters:
+        ///   - interval: The interval at which the underlying playhead observer executes an update
+        ///   - player: `AVPlayer` whose playhead values are emited by the `Publisher`
         init(interval: TimeInterval = 0.25, player: AVPlayer) {
             self.player = player
             self.interval = interval

--- a/AVFoundation-Combine/Video Player/VideoPlayerViewController.swift
+++ b/AVFoundation-Combine/Video Player/VideoPlayerViewController.swift
@@ -23,14 +23,16 @@ final class VideoPlayerViewController: UIViewController {
     /// A `Set` to store all our `Publisher` susbcriptions
     private var subscriptions = Set<AnyCancellable>()
     
-    /// A flag to keep track of whether the user is using `progressSlider` to scrub trough the video timeline. Used to prevent the thumb in the slider from jumping back and forth while `seek` is in progress.
+    /// A flag to keep track of whether the user is actioning `progressSlider` to scrub trough the video timeline. Used to prevent the thumb in the slider from jumping back and forth while `seek` is in progress.
     private var isProgressSliderScrubbing: Bool = false
     
+    /// A flag that is updated by a subcription to `AVPlayer.rate`. Its main function is to decide wheter to `play()` or `pause()` when the user taps the play/pause button
     private var isPlaying: Bool = false
     
     /// Reference to the AVPlayer instance used to support replaying
     private var player: AVPlayer!
     
+    /// A view with custom controls
     lazy private var videoPlayerContentOverlay: VideoPlayerContentOverlay = {
         VideoPlayerContentOverlay()
     }()


### PR DESCRIPTION
Fixes #13 

This cleans up source documentation so that it explicitly mentions the property the `Publisher` is emitting values for and in which way: whether wrapping `NSObject.KeyValueObservingPublisher`, `NotificationCenter.Publisher` or a custom implementation. 